### PR TITLE
Add JCE backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Secret storage API.
 
 ## Usage
 
+Provided backends include [KMS](https://aws.amazon.com/kms/), [buddy](https://github.com/funcool/buddy),
+and JCE (which uses `java.security.KeyStore`, `javax.crypto.Cipher`, and friends). Also available
+is a "dummy" backend that does no decryption.
+
 ### KMS
 
 ```clojure
@@ -27,6 +31,15 @@ Your project dependencies should include (update versions as appropriate):
  [com.cognitect.aws/endpoints "1.1.11.565"]
  [com.cognitect.aws/kms "718.2.448.0"]]
 ```
+
+### JCE
+
+The JCE backend requires [transit](https://github.com/cognitect/transit-clj). You can
+refine what format to use for transit; the default is `:msgpack`.
+
+The JCE backend is most interesting with a PKCS#11 compatible Hardware Security Module.
+This can be run against [SoftHSM](https://www.opendnssec.org/softhsm/) for testing
+without a real HSM.
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -9,11 +9,13 @@
   :profiles {:provided {:dependencies [[com.cognitect.aws/api "0.8.305"]
                                        [com.cognitect.aws/endpoints "1.1.11.565"]
                                        [com.cognitect.aws/kms "718.2.448.0"]
-                                       [buddy/buddy-core "1.5.0"]]}
+                                       [buddy/buddy-core "1.5.0"]
+                                       [com.cognitect/transit-clj "0.8.313"]]}
              :repl {:dependencies [[com.cognitect.aws/api "0.8.305"]
                                    [com.cognitect.aws/endpoints "1.1.11.565"]
                                    [com.cognitect.aws/kms "718.2.448.0"]
-                                   [buddy/buddy-core "1.5.0"]]
+                                   [buddy/buddy-core "1.5.0"]
+                                   [com.cognitect/transit-clj "0.8.313"]]
                     :source-paths ["scripts"]}}
   :repl-options {:init-ns lore.repl}
   :release-tasks [["vcs" "assert-committed"]

--- a/scripts/jce.clj
+++ b/scripts/jce.clj
@@ -5,17 +5,29 @@
 ; Quickstart for macOS, with homebrew:
 ; brew install softhsm
 ; softhsm2-util --init-token --slot 0 --label 'Your SoftHSM'
+; enter your SoftHSM PINs (or supply command-line arguments)
 
 (import '[sun.security.pkcs11 SunPKCS11])
 (import '[java.io ByteArrayInputStream])
 
-(def config "name = SoftHSM\nlibrary = /usr/local/lib/softhsm/libsofthsm2.so\nslotListIndex = 0\nattributes(generate, *, *) = {\n   CKA_TOKEN = true\n}\nattributes(generate, CKO_CERTIFICATE, *) = {\n   CKA_PRIVATE = false\n}\nattributes(generate, CKO_PUBLIC_KEY, *) = {\n   CKA_PRIVATE = false\n}")
+(def config "name = SoftHSM
+library = /usr/local/lib/softhsm/libsofthsm2.so
+slotListIndex = 0
+attributes(generate, *, *) = {
+   CKA_TOKEN = true
+}
+attributes(generate, CKO_CERTIFICATE, *) = {
+   CKA_PRIVATE = false
+}
+attributes(generate, CKO_PUBLIC_KEY, *) = {
+   CKA_PRIVATE = false
+}")
 
 (def provider (SunPKCS11. (ByteArrayInputStream. (.getBytes config))))
 (java.security.Security/addProvider provider)
 
 (require '[lore.api.async.impl.jce :as jce] :reload)
-(def store-password "...")
+(def store-password "...") ; set to your user PIN from softhsm2-util --init-token.
 (def secret-store (jce/->secret-store {:store-type "PKCS11" :store-password store-password :padding :pkcs5}))
 
 (:keystore secret-store)
@@ -25,7 +37,19 @@
 ; this will generate a new secret key with ID 0000.
 ; this key is unexportable, so you can't use it with a different cipher than supported
 ; by the SunPKCS11 provider.
+; We give :pkcs5 padding here
 (def ciphertext (jce/encrypt (:keystore secret-store) plaintext {:padding :pkcs5 :key-id "0000" :generate-key? true}))
+
+; you can create your own padding schemes by defining new pad and unpad multimethods
+; pad arguments:
+;    format -- a keyword format
+;    block-size -- the cipher block size
+;    input-size -- the input size
+; pad should return a byte array containing the padding bytes
+; unpad arguments:
+;    format -- a keyword format
+;    input -- the input to unpad
+; unpad should return the input, with the padding bytes removed
 
 (require '[lore.api.async :as lore])
 (require '[clojure.core.async :as async])

--- a/scripts/jce.clj
+++ b/scripts/jce.clj
@@ -1,0 +1,39 @@
+(in-ns '[lore.repl])
+
+; Example usage with softhsm and Java's PKCS11 provider.
+
+; Quickstart for macOS, with homebrew:
+; brew install softhsm
+; softhsm2-util --init-token --slot 0 --label 'Your SoftHSM'
+
+(import '[sun.security.pkcs11 SunPKCS11])
+(import '[java.io ByteArrayInputStream])
+
+(def config "name = SoftHSM\nlibrary = /usr/local/lib/softhsm/libsofthsm2.so\nslotListIndex = 0\nattributes(generate, *, *) = {\n   CKA_TOKEN = true\n}\nattributes(generate, CKO_CERTIFICATE, *) = {\n   CKA_PRIVATE = false\n}\nattributes(generate, CKO_PUBLIC_KEY, *) = {\n   CKA_PRIVATE = false\n}")
+
+(def provider (SunPKCS11. (ByteArrayInputStream. (.getBytes config))))
+(java.security.Security/addProvider provider)
+
+(require '[lore.api.async.impl.jce :as jce] :reload)
+(def store-password "...")
+(def secret-store (jce/->secret-store {:store-type "PKCS11" :store-password store-password :padding :pkcs5}))
+
+(:keystore secret-store)
+
+(def plaintext (.getBytes "The Moon Rises at Noon."))
+
+; this will generate a new secret key with ID 0000.
+; this key is unexportable, so you can't use it with a different cipher than supported
+; by the SunPKCS11 provider.
+(def ciphertext (jce/encrypt (:keystore secret-store) plaintext {:padding :pkcs5 :key-id "0000" :generate-key? true}))
+
+(require '[lore.api.async :as lore])
+(require '[clojure.core.async :as async])
+
+(def plaintext2 (async/<!! (lore/decrypt secret-store ciphertext)))
+(lore/error? secret-store plaintext2)
+; => false
+
+(import '[java.security MessageDigest])
+(MessageDigest/isEqual plaintext (:plaintext plaintext2))
+; => true

--- a/src/lore/api/async/impl/jce.clj
+++ b/src/lore/api/async/impl/jce.clj
@@ -1,0 +1,145 @@
+(ns lore.api.async.impl.jce
+  (:require [clojure.core.async :as async]
+            [clojure.string :as string]
+            [cognitect.transit :as transit]
+            [lore.api.async :as lore]
+            [lore.util :refer [->bytes error?]])
+  (:import [java.security KeyStore KeyStore$PasswordProtection KeyStore$SecretKeyEntry SecureRandom]
+           [java.io ByteArrayInputStream ByteArrayOutputStream]
+           [javax.crypto Cipher KeyGenerator]
+           [javax.crypto.spec IvParameterSpec]
+           [java.util Arrays]))
+
+; We include padding/unpadding functions here to allow use of
+; PKCS11 Ciphers, which might not support native padding schemes.
+
+(defmulti pad (fn [format _block-size _input-size] format))
+(defmulti unpad (fn [format _input] format))
+
+(defmethod pad :nopadding
+  [_format _block-size _input-size]
+  (byte-array []))
+
+(defmethod pad :pkcs5
+  [_format block-size input-size]
+  (let [n (- block-size (mod input-size block-size))
+        pad (byte-array n)]
+    (Arrays/fill pad (.byteValue n))
+    pad))
+
+(defmethod unpad :nopadding
+  [_format input]
+  input)
+
+(defmethod unpad :pkcs5
+  [_format input]
+  (let [n (bit-and (last input) 0xFF)
+        b (byte-array (- (alength input) n))]
+    (System/arraycopy input 0 b 0 (alength b))
+    b))
+
+(defrecord AsyncKeyStoreSecretStore [^KeyStore keystore provider master-key-password algorithm format padding]
+  lore/IAsyncSecretStore
+  (error? [_this result] (error? result))
+
+  (decrypt [_this v]
+    (let [chan (async/promise-chan)]
+      (async/thread
+        (async/put! chan
+          (try
+            (let [reader (transit/reader (ByteArrayInputStream. (->bytes v)) format)
+                  {:keys [ciphertext iv key-id]} (transit/read reader)
+                  key (let [e (.getEntry keystore key-id (some-> master-key-password (.toCharArray) (KeyStore$PasswordProtection.)))]
+                        (if (instance? KeyStore$SecretKeyEntry e)
+                          (.getSecretKey e)
+                          (throw (ex-info (str "keystore entry with ID " key-id " is not a secret key") {}))))
+                  cipher (doto (if (some? provider)
+                                 (Cipher/getInstance algorithm provider)
+                                 (Cipher/getInstance algorithm))
+                           (.init Cipher/DECRYPT_MODE key (IvParameterSpec. iv)))
+                  plaintext (unpad padding (.doFinal cipher ciphertext))]
+              {:plaintext plaintext})
+            (catch Exception e
+              {:cognitect.anomalies/category :cognitect.anomalies/fault
+               :cognitect.anomalies/message (.getMessage e)
+               :exception e}))))
+      chan)))
+
+(defn- hex
+  [b]
+  (->> b
+       (map #(format "%02x" %))
+       (string/join)))
+
+(defn- ^String cipher-alg
+  [^String spec]
+  (first (.split spec "/")))
+
+(defn- random-bytes
+  ([n] (random-bytes n (SecureRandom.)))
+  ([n random]
+   (let [b (byte-array n)]
+     (.nextBytes random b)
+     b)))
+
+(defn- concat-bytes
+  [b1 b2]
+  (cond
+    (zero? (alength b1)) b2
+    (zero? (alength b2)) b1
+    :else (let [b (byte-array (+ (alength b1) (alength b2)))]
+            (System/arraycopy b1 0 b 0 (alength b1))
+            (System/arraycopy b2 0 b (alength b1) (alength b2))
+            b)))
+
+(defn encrypt
+  [^KeyStore keystore plaintext {:keys [key-id algorithm format iv generate-key? key-password key-size padding]
+                                 :or {algorithm "AES/CBC/NoPadding"
+                                      format :msgpack
+                                      key-size 128
+                                      padding :nopadding}}]
+  (let [key (if-let [key (when (some? key-id)
+                           (when-let [entry (.getEntry keystore key-id (some-> key-password (.toCharArray) (KeyStore$PasswordProtection.)))]
+                             (when (instance? KeyStore$SecretKeyEntry entry)
+                               (.getSecretKey ^KeyStore$SecretKeyEntry entry))))]
+              key
+              (if generate-key?
+                (let [key-id (or key-id (-> (random-bytes 8) hex))
+                      kg (doto (KeyGenerator/getInstance (cipher-alg algorithm) (.getProvider keystore))
+                           (.init key-size))
+                      key (.generateKey kg)]
+                  (.setKeyEntry keystore key-id key key-password nil)
+                  key)
+                (throw (ex-info "no suitable secret key to encrypt" {:key-id key-id}))))
+        cipher (Cipher/getInstance ^String algorithm (.getProvider keystore))
+        iv (or iv (random-bytes (.getBlockSize cipher)))]
+    (.init cipher Cipher/ENCRYPT_MODE key (IvParameterSpec. iv))
+    (let [pt (->bytes plaintext)
+          ct1 (.update cipher pt)
+          ct2 (.doFinal cipher (pad padding (.getBlockSize cipher) (alength pt)))
+          ciphertext (concat-bytes ct1 ct2)
+          result {:ciphertext ciphertext :iv iv :key-id key-id}
+          bout (ByteArrayOutputStream.)
+          writer (transit/writer bout format)]
+      (transit/write writer result)
+      (.toByteArray bout))))
+
+(defn- ->char-array
+  [s]
+  (cond
+    (-> s class .getComponentType (= Character/TYPE)) s
+    (string? s) (.toCharArray s)))
+
+(defn ->secret-store
+  [{:keys [store-type store-password algorithm key-password format padding]
+    :or {algorithm "AES/CBC/NoPadding"
+         format :msgpack
+         padding :nopadding}}]
+  (let [keystore (doto (KeyStore/getInstance store-type)
+                   (.load nil (->char-array store-password)))]
+    (->AsyncKeyStoreSecretStore keystore
+                                (.getProvider keystore)
+                                key-password
+                                algorithm
+                                format
+                                padding)))

--- a/src/lore/component.clj
+++ b/src/lore/component.clj
@@ -15,6 +15,9 @@
               :buddy (dynacall 'buddy/buddy-core
                                'lore.api.async.impl.buddy/->buddy-store
                                arguments)
+              :jce (dynacall 'cognitect.transit/transit-clj
+                             'lore.api.async.impl.jce/->secret-store
+                             arguments)
               :dummy (lore.api.async.impl.dummy/->DummySecretStore)
               nil (throw (IllegalArgumentException. "argument `store-type' is required"))
               (throw (IllegalArgumentException. (str "invalid store-type: " store-type))))))


### PR DESCRIPTION
* scripts/jce.clj: new file. Example that shows how to use with a
  PKCS11 KeyStore.
* src/lore/api/async/impl/jce.clj: new namespace.
* src/lore/component.clj: support jce store type.
* project.clj: add transit dependency.